### PR TITLE
Fix HtmlParser not parse last char }

### DIFF
--- a/loopme-sdk/src/main/java/com/loopme/parser/HtmlParser.java
+++ b/loopme-sdk/src/main/java/com/loopme/parser/HtmlParser.java
@@ -31,7 +31,7 @@ public class HtmlParser {
     public HtmlParser(String html) {
         this.mHtml = html;
         try {
-            mJsonScript = mHtml.substring(mHtml.indexOf("{"), mHtml.lastIndexOf("}"));
+            mJsonScript = mHtml.substring(mHtml.indexOf("{"), mHtml.lastIndexOf("}") + 1);
         } catch (Exception e) {
             Logging.out(LOG_TAG, "Not appropriate ad type or response format, dimensions are taken by default ");
         }


### PR DESCRIPTION
It was:
        String mHtml = "asdf{ 123 }asdf";
        String mJsonScript = mHtml.substring(mHtml.indexOf("{"), mHtml.lastIndexOf("}") );
        System.out.println(mJsonScript); // { 123 

After fix:
        String mHtml = "asdf{ 123 }asdf";
        String mJsonScript = mHtml.substring(mHtml.indexOf("{"), mHtml.lastIndexOf("}") + 1);
        System.out.println(mJsonScrip); // { 123 }
