### PR TITLE
Build adapters and SDK with Java 8

### DIFF
--- a/bridges/admob/adapter/build.gradle.kts
+++ b/bridges/admob/adapter/build.gradle.kts
@@ -4,9 +4,17 @@ plugins {
 
 android {
     namespace = "com.admob.mediation.adapters"
+    compileSdkVersion(34)
+    
     defaultConfig {
         consumerProguardFiles("proguard-rules.pro")
         buildConfigField("String", "VERSION_NAME", project.findProperty("VERSION_NAME") as? String ?: "")
+        minSdkVersion(22)
+        targetSdkVersion(34)
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/bridges/appLovin/adapter/build.gradle.kts
+++ b/bridges/appLovin/adapter/build.gradle.kts
@@ -4,9 +4,17 @@ plugins {
 
 android {
     namespace = "com.applovin.mediation.adapters"
+    compileSdkVersion(34)
+
     defaultConfig {
         consumerProguardFiles("proguard-rules.pro")
         buildConfigField("String", "VERSION_NAME", project.findProperty("VERSION_NAME") as? String ?: "")
+        minSdkVersion(22)
+        targetSdkVersion(34)
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/bridges/appLovin/app/build.gradle.kts
+++ b/bridges/appLovin/app/build.gradle.kts
@@ -9,6 +9,7 @@ android {
         applicationId = "com.loopme.applovin.app"
         versionCode = 1
         versionName ="1.0"
+        minSdkVersion(22)
     }
 
     buildFeatures {

--- a/bridges/ironSource/adapter/build.gradle.kts
+++ b/bridges/ironSource/adapter/build.gradle.kts
@@ -4,9 +4,17 @@ plugins {
 
 android {
     namespace = "com.ironsource.adapters.custom.loopme"
+    compileSdkVersion(34)
+
     defaultConfig {
         consumerProguardFiles("proguard-rules.pro")
         buildConfigField("String", "VERSION_NAME", project.findProperty("VERSION_NAME") as? String ?: "")
+        minSdkVersion(22)
+        targetSdkVersion(34)
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/bridges/ironSource/app/build.gradle.kts
+++ b/bridges/ironSource/app/build.gradle.kts
@@ -9,6 +9,7 @@ android {
         applicationId = "com.loopme.ironsource_mediation_sample"
         versionCode = 1
         versionName ="1.0"
+        minSdkVersion(22)
     }
 
     buildFeatures {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
 # configuration file for building snapshots and releases with jitpack.io
 jdk:
-  - openjdk17
+  - openjdk8
 before_install:
-  - sdk install java 17.0.1-open
-  - sdk use java 17.0.1-open
+  - sdk install java 8.0.292-open
+  - sdk use java 8.0.292-open
   - java -version

--- a/loopme-sdk/build.gradle.kts
+++ b/loopme-sdk/build.gradle.kts
@@ -4,11 +4,20 @@ plugins {
 
 android {
     namespace = "com.loopme"
+    compileSdkVersion(34)
+
     defaultConfig {
         consumerProguardFiles("proguard-rules.pro")
         buildConfigField("String", "OM_SDK_JS_URL", project.findProperty("OM_SDK_JS_URL") as? String ?: "")
         buildConfigField("String", "OM_SDK_PARTNER", project.findProperty("OM_SDK_PARTNER") as? String ?: "")
         buildConfigField("String", "VERSION_NAME", project.findProperty("VERSION_NAME") as? String ?: "")
+        minSdkVersion(22)
+        targetSdkVersion(34)
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION
This PR is an attempt to address [SDK-236](https://loopme.atlassian.net/browse/SDK-236). It shifts the jitpack configuration to use JDK 8 & adjusts the SDK and adapter gradle files to set compileSDK, minSDK, targetSDK and Java compile options.

[SDK-236]: https://loopme.atlassian.net/browse/SDK-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ